### PR TITLE
Remove if there is a file

### DIFF
--- a/jenkins-backup.sh
+++ b/jenkins-backup.sh
@@ -19,7 +19,9 @@ if [ -z "$JENKINS_HOME" -o -z "$DIST_FILE" ] ; then
   exit 1
 fi
 
-rm $TMP_DIR/$TMP_TAR_NAME
+if [[ -f "$TMP_DIR/$TMP_TAR_NAME" ]]; then
+    rm $TMP_DIR/$TMP_TAR_NAME
+fi
 rm -rf $ARC_DIR
 mkdir $ARC_DIR
 mkdir $ARC_DIR/plugins


### PR DESCRIPTION
It's a minor fix. Remove only when there's tar file

```
rm: cannot remove `/var/lib/jenkins/tmp/jenkins-backup-script/tmp/archive.tar.gz': No such file or directory
```

Thanks for creating very handy script!
