### PR TITLE
Escape bug fix and few tweaks

### DIFF
--- a/jenkins-backup.sh
+++ b/jenkins-backup.sh
@@ -32,7 +32,6 @@ cp -R "$JENKINS_HOME/users/"* "$ARC_DIR/users"
 cd "$JENKINS_HOME/jobs/"
 ls -1 | while read job_name
 do
-  echo $job_name
   mkdir -p "$ARC_DIR/jobs/$job_name/"
   cp "$JENKINS_HOME/jobs/$job_name/"*.xml "$ARC_DIR/jobs/$job_name/"
 done


### PR DESCRIPTION
If the Jenkins Task name would be `Backup /var/lib/jenkins daily` then previously `rm -rf $ARC_DIR` would kick off `rm -rf /var/lib/jenkins/workspace/Backup /var/lib/jenkins daily/tmp/jenkins-backup`. So potentially it could be dangerous. Besides that, if the workspace had space in the title for e.a. `Backup Jenkins` then it would fail. So I've added escaping everywhere just to be safe and have it working.

Additionally I've changed archive paths so that they would respect given target in respect to workspace directory. For example `./jenkins-backup.sh /var/lib/jenkins ./backup/20141127160526.tar.gz` would create archive in workspace instead of within tmp
