### PR TITLE
Get all plugins, cleaner tar file

### DIFF
--- a/jenkins-backup.sh
+++ b/jenkins-backup.sh
@@ -27,7 +27,9 @@ mkdir -p "$ARC_DIR/"{plugins,jobs,users}
 
 cp "$JENKINS_HOME/"*.xml "$ARC_DIR"
 cp "$JENKINS_HOME/plugins/"*.[hj]pi "$ARC_DIR/plugins"
-cp "$JENKINS_HOME/plugins/"*.[hj]pi.pinned "$ARC_DIR/plugins"
+if [ -f "$JENKINS_HOME/plugins/"*.[hj]pi.pinned ] ; then
+  cp "$JENKINS_HOME/plugins/"*.[hj]pi.pinned "$ARC_DIR/plugins"
+fi
 cp -R "$JENKINS_HOME/users/"* "$ARC_DIR/users"
 
 cd "$JENKINS_HOME/jobs/"

--- a/jenkins-backup.sh
+++ b/jenkins-backup.sh
@@ -26,7 +26,8 @@ rm -rf "$ARC_DIR"
 mkdir -p "$ARC_DIR/"{plugins,jobs,users}
 
 cp "$JENKINS_HOME/"*.xml "$ARC_DIR"
-cp "$JENKINS_HOME/plugins/"*.jpi "$ARC_DIR/plugins"
+cp "$JENKINS_HOME/plugins/"*.[hj]pi "$ARC_DIR/plugins"
+cp "$JENKINS_HOME/plugins/"*.[hj]pi.pinned "$ARC_DIR/plugins"
 cp -R "$JENKINS_HOME/users/"* "$ARC_DIR/users"
 
 cd "$JENKINS_HOME/jobs/"

--- a/jenkins-backup.sh
+++ b/jenkins-backup.sh
@@ -37,8 +37,10 @@ do
   cp "$JENKINS_HOME/jobs/$job_name/"*.xml "$ARC_DIR/jobs/$job_name/"
 done
 
+cd "$TMP_DIR"
+tar -czvf "$TMP_DIR/$TMP_TAR_NAME" "$ARC_NAME/"*
+
 cd "$CUR_DIR"
-tar -czvf "$TMP_DIR/$TMP_TAR_NAME" "$TMP_DIR/$ARC_NAME/"*
 cp "$TMP_DIR/$TMP_TAR_NAME" "$DIST_FILE"
 
 exit 0


### PR DESCRIPTION
A number of plugins are .hpi instead of .jpi, and would be nice to save which ones were pinned as well.

Also tweaks the structure of the tar file, so that a listing shows
```
jenkins-backup/config.xml
jenkins-backup/plugins/...
```
instead of
```
/home/maafy6/jenkins-backup-script/tmp/jenkins-backup/config.xml
/home/maafy6/jenkins-backup-script/tmp/jenkins-backup/plugins/...
```

Just makes for less time spent counting how many folders I have to add to `tar --strip-components`.