### PR TITLE
fix jenkins backup if some directories don't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ bundle exec rake test
 ## rotate backup files
 ```bash
 # keep backup with latest 30 days
-find /path/to/backup_* -mtime +30 | xargs rm -f
+find /path/to/backup_* -mtime +30 -delete
 ```
 
 ## Restore commands

--- a/jenkins-backup.sh
+++ b/jenkins-backup.sh
@@ -19,13 +19,11 @@ if [ -z "$JENKINS_HOME" -o -z "$DEST_FILE" ] ; then
   exit 1
 fi
 
-if [[ -f "$TMP_DIR/$TMP_TAR_NAME" ]]; then
-    rm "$TMP_DIR/$TMP_TAR_NAME"
-fi
-rm -rf "$ARC_DIR"
+rm -rf "$ARC_DIR" "$TMP_DIR/$TMP_TAR_NAME"
 mkdir -p "$ARC_DIR/"{plugins,jobs,users,secrets}
 
 cp "$JENKINS_HOME/"*.xml "$ARC_DIR"
+
 cp "$JENKINS_HOME/plugins/"*.[hj]pi "$ARC_DIR/plugins"
 hpi_pinned_count=$(find $JENKINS_HOME/plugins/ -name *.hpi.pinned | wc -l)
 jpi_pinned_count=$(find $JENKINS_HOME/plugins/ -name *.jpi.pinned | wc -l)
@@ -49,8 +47,9 @@ if [ -d "$JENKINS_HOME/jobs/" ] ; then
   done
 fi
 
+cd "$TMP_DIR"
 tar -czvf "$TMP_DIR/$TMP_TAR_NAME" "$ARC_NAME/"*
-
-cp "$TMP_DIR/$TMP_TAR_NAME" "$DEST_FILE"
+mv -f "$TMP_DIR/$TMP_TAR_NAME" "$DEST_FILE"
+rm -rf "$ARC_DIR"
 
 exit 0

--- a/jenkins-backup.sh
+++ b/jenkins-backup.sh
@@ -12,14 +12,14 @@ readonly CUR_DIR=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
 readonly TMP_DIR="$CUR_DIR/tmp"
 readonly ARC_NAME="jenkins-backup"
 readonly ARC_DIR="$TMP_DIR/$ARC_NAME"
-readonly TMP_TAR_NAME="archive.tar.gz"
+readonly TMP_TAR_NAME="$TMP_DIR/archive.tar.gz"
 
 if [ -z "$JENKINS_HOME" -o -z "$DEST_FILE" ] ; then
   usage >&2
   exit 1
 fi
 
-rm -rf "$ARC_DIR" "$TMP_DIR/$TMP_TAR_NAME"
+rm -rf "$ARC_DIR" "$TMP_TAR_NAME"
 mkdir -p "$ARC_DIR/"{plugins,jobs,users,secrets}
 
 cp "$JENKINS_HOME/"*.xml "$ARC_DIR"
@@ -48,8 +48,8 @@ if [ -d "$JENKINS_HOME/jobs/" ] ; then
 fi
 
 cd "$TMP_DIR"
-tar -czvf "$TMP_DIR/$TMP_TAR_NAME" "$ARC_NAME/"*
-mv -f "$TMP_DIR/$TMP_TAR_NAME" "$DEST_FILE"
+tar -czvf "$TMP_TAR_NAME" "$ARC_NAME/"*
+mv -f "$TMP_TAR_NAME" "$DEST_FILE"
 rm -rf "$ARC_DIR"
 
 exit 0

--- a/jenkins-backup.sh
+++ b/jenkins-backup.sh
@@ -32,20 +32,25 @@ jpi_pinned_count=$(find $JENKINS_HOME/plugins/ -name *.jpi.pinned | wc -l)
 if [ $hpi_pinned_count -ne 0 -o $jpi_pinned_count -ne 0 ]; then
   cp "$JENKINS_HOME/plugins/"*.[hj]pi.pinned "$ARC_DIR/plugins"
 fi
-cp -R "$JENKINS_HOME/users/"* "$ARC_DIR/users"
-cp -R "$JENKINS_HOME/secrets/"* "$ARC_DIR/secrets"
 
-cd "$JENKINS_HOME/jobs/"
-ls -1 | while read job_name
-do
-  mkdir -p "$ARC_DIR/jobs/$job_name/"
-  find "$JENKINS_HOME/jobs/$job_name/" -maxdepth 1 -name "*.xml" | xargs -I {} cp {} "$ARC_DIR/jobs/$job_name/"
-done
+if [ -d "$JENKINS_HOME/users/" ] ; then
+  cp -R "$JENKINS_HOME/users/"* "$ARC_DIR/users"
+fi
 
-cd "$TMP_DIR"
+if [ -d "$JENKINS_HOME/secrets/"] ; then
+  cp -R "$JENKINS_HOME/secrets/"* "$ARC_DIR/secrets"
+fi
+
+if [ -d "$JENKINS_HOME/jobs/" ] ; then
+  cd "$JENKINS_HOME/jobs/"
+  ls -1 | while read job_name ; do
+    mkdir -p "$ARC_DIR/jobs/$job_name/"
+    find "$JENKINS_HOME/jobs/$job_name/" -maxdepth 1 -name "*.xml" | xargs -I {} cp {} "$ARC_DIR/jobs/$job_name/"
+  done
+fi
+
 tar -czvf "$TMP_DIR/$TMP_TAR_NAME" "$ARC_NAME/"*
 
-cd "$CUR_DIR"
 cp "$TMP_DIR/$TMP_TAR_NAME" "$DEST_FILE"
 
 exit 0

--- a/jenkins-backup.sh
+++ b/jenkins-backup.sh
@@ -35,7 +35,7 @@ if [ -d "$JENKINS_HOME/users/" ] ; then
   cp -R "$JENKINS_HOME/users/"* "$ARC_DIR/users"
 fi
 
-if [ -d "$JENKINS_HOME/secrets/"] ; then
+if [ -d "$JENKINS_HOME/secrets/" ] ; then
   cp -R "$JENKINS_HOME/secrets/"* "$ARC_DIR/secrets"
 fi
 


### PR DESCRIPTION
the main bug fix here is commit 1c0508e which checks if directories exist before attempting to copy their contents into the archive directory.
commit fb1f419 cleans up some of the temporary files and directories, to not leave so much stuff around after the backup script exists.
commit c1ed1ab makes the TMP_TAR_NAME variable contain an absolute pathname which simplifies it's use.
and finally commit c65ef6f suggests to use the -delete argument for the find command, instead of the "xargs rm" anachronism.