### PR TITLE
Make jenkins-backup.sh generic

### DIFF
--- a/jenkins-backup.sh
+++ b/jenkins-backup.sh
@@ -22,7 +22,7 @@ fi
 rm -rf "$ARC_DIR" "$TMP_TAR_NAME"
 mkdir -p "$ARC_DIR/"{plugins,jobs,users,secrets}
 
-cp "$JENKINS_HOME/"*.xml "$ARC_DIR"
+cp "$JENKINS_HOME/"*.xml "$ARC_DIR" || true
 
 cp "$JENKINS_HOME/plugins/"*.[hj]pi "$ARC_DIR/plugins"
 hpi_pinned_count=$(find $JENKINS_HOME/plugins/ -name *.hpi.pinned | wc -l)
@@ -40,7 +40,13 @@ if [ -d "$JENKINS_HOME/secrets/" ] ; then
 fi
 
 if [ -d "$JENKINS_HOME/jobs/" ] ; then
-  cd "$JENKINS_HOME/jobs/"
+  readonly JOB_DIR="$JENKINS_HOME/jobs/"
+elif [ -d "$JENKINS_HOME/workspace/" ]; then
+  readonly JOB_DIR="$JENKINS_HOME/workspace/"
+fi
+
+if [ -n $JOB_DIR ]; then
+  cd $JOB_DIR;
   ls -1 | while read job_name ; do
     mkdir -p "$ARC_DIR/jobs/$job_name/"
     find "$JENKINS_HOME/jobs/$job_name/" -maxdepth 1 -name "*.xml" | xargs -I {} cp {} "$ARC_DIR/jobs/$job_name/"

--- a/jenkins-backup.sh
+++ b/jenkins-backup.sh
@@ -20,11 +20,14 @@ if [ -z "$JENKINS_HOME" -o -z "$DEST_FILE" ] ; then
 fi
 
 rm -rf "$ARC_DIR" "$TMP_TAR_NAME"
-mkdir -p "$ARC_DIR/"{plugins,jobs,users,secrets}
 
 cp "$JENKINS_HOME/"*.xml "$ARC_DIR" || true
 
-cp "$JENKINS_HOME/plugins/"*.[hj]pi "$ARC_DIR/plugins"
+if [ -d "$JENKINS_HOME/plugins/" ] ; then
+  mkdir -p "$ARC_DIR/plugins"
+  cp "$JENKINS_HOME/plugins/"*.[hj]pi "$ARC_DIR/plugins"
+fi
+
 hpi_pinned_count=$(find $JENKINS_HOME/plugins/ -name *.hpi.pinned | wc -l)
 jpi_pinned_count=$(find $JENKINS_HOME/plugins/ -name *.jpi.pinned | wc -l)
 if [ $hpi_pinned_count -ne 0 -o $jpi_pinned_count -ne 0 ]; then
@@ -32,16 +35,20 @@ if [ $hpi_pinned_count -ne 0 -o $jpi_pinned_count -ne 0 ]; then
 fi
 
 if [ -d "$JENKINS_HOME/users/" ] ; then
+  mkdir -p "$ARC_DIR/users"
   cp -R "$JENKINS_HOME/users/"* "$ARC_DIR/users"
 fi
 
 if [ -d "$JENKINS_HOME/secrets/" ] ; then
+  mkdir -p "$ARC_DIR/secrets"
   cp -R "$JENKINS_HOME/secrets/"* "$ARC_DIR/secrets"
 fi
 
 if [ -d "$JENKINS_HOME/jobs/" ] ; then
+  mkdir -p "$ARC_DIR/jobs"
   readonly JOB_DIR="$JENKINS_HOME/jobs/"
 elif [ -d "$JENKINS_HOME/workspace/" ]; then
+  mkdir -p "$ARC_DIR/workspace"
   readonly JOB_DIR="$JENKINS_HOME/workspace/"
 fi
 


### PR DESCRIPTION
This makes the backup script more generic so that it can be run in a multi-configuration job against slave nodes and/or the master node. When you have an environment where jobs are restricted to running on nodes with specific configurations then xml configuration files may not exist on the master. Slaves seem to have a slightly different folder structure than the master, and this pull request takes that into account.

Also, this makes the backup folder structure match the existing folder structure of the backed up instance. If a plugins directory doesn't exist on the host, don't create one in the backup etc.