### PR TITLE
Backup script was failing when projects have folders with spaces

### DIFF
--- a/jenkins-backup.sh
+++ b/jenkins-backup.sh
@@ -46,7 +46,7 @@ fi
 function backup_jobs {
   local run_in_path=$1
   local rel_depth=${run_in_path#$JENKINS_HOME/jobs/}
-  cd $run_in_path
+  cd "$run_in_path"
   find . -maxdepth 1 -type d | while read job_name ; do
     [ "$job_name" = "." ] && continue
     [ "$job_name" = ".." ] && continue


### PR DESCRIPTION
Backup script was failing when there were spaces in project folders. This small fix - adding quotes to cd command fixes that